### PR TITLE
Add email configuration

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,8 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import User from 'src/user/infra/typeorm/entities/User';
 import Body from 'src/user/infra/typeorm/entities/Body';
+import { MailerModule } from '@nestjs-modules/mailer';
+import { mailerConfig } from '../config/mailer/mailer.config';
 
 @Module({
   imports: [
@@ -18,6 +20,7 @@ import Body from 'src/user/infra/typeorm/entities/Body';
       database: process.env.TYPEORM_DATABASE,
       entities: [User, Body],
     }),
+    MailerModule.forRoot(mailerConfig),
     TypeOrmModule.forFeature([User, Body]),
     UserModule,
   ],

--- a/src/config/mailer/mailer.config.ts
+++ b/src/config/mailer/mailer.config.ts
@@ -1,0 +1,24 @@
+import { MailerOptions } from '@nestjs-modules/mailer';
+import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+export const mailerConfig: MailerOptions = {
+  transport: {
+    host: process.env.MAIL_HOST,
+    port: Number(process.env.MAIL_PORT),
+    secure: Boolean(process.env.MAIL_SECURE),
+    auth: {
+      user: process.env.MAIL_USER,
+      pass: process.env.MAIL_PASS,
+    },
+  },
+  template: {
+    dir: path.resolve(__dirname, '..', '..', '..', 'templates'),
+    adapter: new HandlebarsAdapter(),
+    options: {
+      strict: true,
+    },
+  },
+};


### PR DESCRIPTION
O ambiente está configurado para implementar as demais funcionalidades que envolvem o envio de emails. Para isso, basta configurar o .env e criar um template de email dentro da pasta templates no diretório raiz do projeto. 